### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ playbooks/create-cluster.yml \
   -e worker_count=<number of workers, defaults to 2> \
   -e image=<image slug to use, defaults to ubuntu-22.04> \
   -e flavor=<flavor to use, defaults to flex-8-4> \
-  -e volume_size_gb=<root volume size, defaults to 25>
+  -e volume_size_gb=<root volume size, defaults to 25> \
+  -e kubelet_extra_args<passed to kubelet, not defined by default>
 ```
 
 The Kubernetes version installed is the latest one found. You can specify another version, either exactly (e.g. `1.27.1`, or roughly (`1.27`). To see the exact set of versions used, run `helpers/release-set <version>`.

--- a/playbooks/build-container.yml
+++ b/playbooks/build-container.yml
@@ -32,8 +32,14 @@
         delete: true
         times: true
 
+    - name: Create shared cache
+      file:
+        path: /var/cache/container
+        state: directory
+
     - name: Build container
       command: >
-        podman build . -t '{{ tag }}' {{ extra }}
+        podman build . -v /var/cache/container:/var/cache/container
+        -t '{{ tag }}' {{ extra }}
       args:
         chdir: /tmp/build-container

--- a/playbooks/create-cluster.yml
+++ b/playbooks/create-cluster.yml
@@ -447,6 +447,12 @@
         content: 'resolvConf: /etc/kubernetes/resolv.conf'
         dest: /etc/kubernetes/kubeadm-patches/kubeletconfiguration.yaml
 
+    - name: Store kubelet extra args
+      copy:
+        content: "KUBELET_EXTRA_ARGS={{ kubelet_extra_args }}\n"
+        dest: /etc/default/kubelet
+      when: kubelet_extra_args is defined
+
 - name: Setup Controls
   hosts: controls[0]
   become: true

--- a/playbooks/create-cluster.yml
+++ b/playbooks/create-cluster.yml
@@ -589,6 +589,14 @@
         flat: true
       run_once: true
 
+    - name: Set kubeconfig mode (to avoid warnings)
+      file:
+        path: '{{ playbook_dir }}/../cluster/admin.conf'
+        mode: '0600'
+      run_once: true
+      become: false
+      delegate_to: localhost
+
 - name: Store inventory
   hosts: localhost
   gather_facts: false


### PR DESCRIPTION
The following changes are useful for our CCM, as it allows me to pass `--cloud-provider=external` to all kubelets, and with the container cache I can do fast rebuilds.